### PR TITLE
Added maxlength parameter to deposit title field on user and admin screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_Store
 vendor/
+
+# IDEs
+*.code-workspace
+.idea
+.vscode

--- a/admin-screens.php
+++ b/admin-screens.php
@@ -66,7 +66,7 @@ function humcore_deposit_metabox( $post ) {
 		</p>
 		<p>
 			<label>Title<br>
-				<input type="text" name="aggregator_title_unchanged" class="widefat" value="<?php echo esc_attr( $aggregator_metadata['title_unchanged'] ); ?>">
+				<input type="text" name="aggregator_title_unchanged" class="widefat" maxlength="255" value="<?php echo esc_attr( $aggregator_metadata['title_unchanged'] ); ?>">
 			</label>
 		</p>
 		<p>

--- a/screens.php
+++ b/screens.php
@@ -283,7 +283,7 @@ function humcore_display_deposit_form( $current_group_id, $user_id, $user_login,
 	<div id="deposit-title-entry">
 <br />
 		<label for="deposit-title">Title</label>
-		<input type="text" id="deposit-title-unchanged" name="deposit-title-unchanged" size="75" class="long"
+		<input type="text" id="deposit-title-unchanged" name="deposit-title-unchanged" size="75" maxlength="255" class="long"
 		<?php
 		if ( ! empty( $prev_val['deposit-title-unchanged'] ) ) {
 			echo ' value="' . wp_kses(


### PR DESCRIPTION
Added `maxlength="255"` to the Title field on both the regular user and admin user screens.

**Note** The admin screen allows you to set the WordPress page title for a deposit independently of the  deposit title. I didn't see any way to change this. It may be a WP setting (maximum length of a WP page). This should not affect the MODS record.