### PR TITLE
Fixed subject formatting for CORE deposit search results

### DIFF
--- a/screens.php
+++ b/screens.php
@@ -1159,6 +1159,15 @@ if ( ! empty( $highlights ) ) {
 <dt>Search term matches:</dt><dd></dd>
 <?php
 foreach ( $highlights as $field => $highlight ) {
+  // for Subject ONLY we extract the subject from "1234:Music:topic"
+  if($field == "Subject"){
+    $subject_list = array();
+    foreach ( $highlight as $fast_subject ){
+      [$id, $subject, $topic] = explode(":", $fast_subject);
+      $subject_list[] = $subject;
+    }
+    $highlight = $subject_list;
+  }
 	echo '<dt>' . $field . '</dt>';
 	echo '<dd>... ' . implode( ' ( ... ) ', $highlight ) . ' ...</dd>';
 }


### PR DESCRIPTION
In the CORE search results there is a section called "Search term matches:" that shows matches between the search string entered and different fields (title, subjects, tags, etc). The subject matches were being displayed as the full subject

"123:Music:topic"

rather than *just* the subject "Music"

Fixed this by editing the match result returned  and extracting just the subject field out of it.